### PR TITLE
Add CONTRIBUTING guide with commit guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to **EchoesOfTomorrow**! To keep the project history clear and helpful, follow these commit guidelines.
+
+## Commit Messages
+- **Be descriptive**. Summarize what the change does, e.g. `Add initial Construct build files` or `Update assets for level 2`.
+- Use the present tense and an imperative voice (`Fix bug` not `Fixed bug`).
+- Keep the first line under 50 characters if possible.
+- Provide additional context in a body paragraph if the change is complex.
+
+By keeping messages concise and meaningful, we make it easier for everyone to review and understand the project history.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # EchoesOfTomorrow
 Game Development &lt;SSDG>
+
+For contribution and commit guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- document commit message conventions in `CONTRIBUTING.md`
- reference the new guide from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ce65c2148323b5da0c5df894f9ea